### PR TITLE
Response with timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ $handlerBuilder->addRoute(
         ->build()
 );
 
+// Route with a Guzzle Timeout
+$handlerBuilder->addRoute(
+      $rb->new()
+          ->withMethod('GET')
+          ->withPath('/slow/api')
+          ->withException(new ConnectException(
+              'Timed out after 30 seconds',
+              new Request('GET', '/slow/api')
+          ))
+          ->build()
+  );
+
 $clientBuilder = new MockedGuzzleClientBuilder($handlerBuilder);
 
 return $clientBuilder->build();

--- a/src/MockedClient/Route/RouteBuilder.php
+++ b/src/MockedClient/Route/RouteBuilder.php
@@ -8,6 +8,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Throwable;
 
 class RouteBuilder
 {
@@ -52,6 +53,15 @@ class RouteBuilder
     {
         $this->handler = static function (RequestInterface $request) use ($response): ResponseInterface {
             return $response;
+        };
+
+        return $this;
+    }
+
+    public function withException(Throwable $exception): self
+    {
+        $this->handler = static function (RequestInterface $request) use ($exception): void {
+            throw $exception;
         };
 
         return $this;

--- a/tests/Route/RouteBuilderTest.php
+++ b/tests/Route/RouteBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DoppioGancio\MockedClient\Tests\Route;
 
 use DoppioGancio\MockedClient\Route\RouteBuilder;
+use Exception;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Http\Discovery\Psr17FactoryDiscovery;
@@ -31,6 +32,23 @@ class RouteBuilderTest extends TestCase
         $response = $route->getHandler()(new Request('GET', '/country?nonce=12345&code=it&page=2'));
         assert($response instanceof ResponseInterface);
         $this->assertEquals(123, $response->getStatusCode());
+    }
+
+    public function testTimeout(): void
+    {
+        $builder = new RouteBuilder(
+            Psr17FactoryDiscovery::findResponseFactory(),
+            Psr17FactoryDiscovery::findStreamFactory(),
+        );
+
+        $route = $builder
+            ->withMethod('GET')
+            ->withPath('/country')
+            ->withException(new Exception('Timed out after 30 seconds'))
+            ->build();
+
+        $this->expectExceptionMessage('Timed out after 30 seconds');
+        $route->getHandler()(new Request('GET', '/country?nonce=12345&code=it&page=2'));
     }
 
     public function testIncompleteRoute(): void


### PR DESCRIPTION
# Goal
The goal is to simulate a timeout for a certain request in a test.

## First solution: sleep for n seconds
A handler with that "sleep" for n seconds, where n > default timeout, I thought it was enough, but apparently,
 in case of timeout, the client will throw an error.

## Second solution: a response with an exception
Having a more generic route with an exception will cover also the timeout scenario. This is a specific example for guzzle:

```php
$rb->new()
         ->withMethod('GET')
         ->withPath('/slow/api')
         ->withException(new ConnectException(
                  'Timed out after 30 seconds',
                  new Request('GET', '/slow/api')
         ))
         ->build()
```