### PR TITLE
Add relative route support

### DIFF
--- a/src/MockedClient/HandlerBuilder.php
+++ b/src/MockedClient/HandlerBuilder.php
@@ -58,7 +58,10 @@ class HandlerBuilder
             );
 
             $serverRequest = $this->serverRequestFactory
-                ->createServerRequest($request->getMethod(), $request->getUri());
+                ->createServerRequest(
+                    $request->getMethod(),
+                    sprintf('/%s', ltrim($request->getUri()->__toString(), '/'))
+                );
 
             try {
                 $response = $router->dispatch($serverRequest);

--- a/tests/HandlerStackBuilderTest.php
+++ b/tests/HandlerStackBuilderTest.php
@@ -69,6 +69,13 @@ class HandlerStackBuilderTest extends TestCase
         $this->getMockedClient()->request('GET', '/not/existing/route');
     }
 
+    public function testRelativeRoute(): void
+    {
+        $response = $this->getMockedClient()->request('GET', 'country/IT');
+        $body     = (string) $response->getBody();
+        $this->assertEquals('{"id":"+39","code":"IT","name":"Italy"}', $body);
+    }
+
     private function getMockedClient(): Client
     {
         $handlerBuilder = new HandlerBuilder(


### PR DESCRIPTION
League's `$router->map` always rewrites the route to an absolute path. I've added that logic to the `createServerRequest` so relative routes can now be supported.