### PR TITLE
Callback route builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ $client = $clientBuilder->build();
 1. [Route with a file](./docs/route-with-file-response.md)
 2. [Route with a string](./docs/route-with-string-response.md)
 3. [Route with consecutive calls](./docs/route-with-consecutive-calls.md)
-3. [Route with callbacks](./docs/route-with-callbacks.md)
-4. [Guzzle client with middlewares](./docs/route-with-consecutive-calls.md)
+4. [Route with callbacks](./docs/route-with-callbacks.md)
+5. [Guzzle client with middlewares](./docs/route-with-consecutive-calls.md)
 
 ## How to use the client
 ```php

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ $client = $clientBuilder->build();
 1. [Route with a file](./docs/route-with-file-response.md)
 2. [Route with a string](./docs/route-with-string-response.md)
 3. [Route with consecutive calls](./docs/route-with-consecutive-calls.md)
+3. [Route with callbacks](./docs/route-with-callbacks.md)
 4. [Guzzle client with middlewares](./docs/route-with-consecutive-calls.md)
 
 ## How to use the client

--- a/docs/route-with-callbacks.md
+++ b/docs/route-with-callbacks.md
@@ -1,0 +1,44 @@
+## Route with callbacks
+
+```php
+$builder = new CallbackRouteBuilder(
+    Psr17FactoryDiscovery::findResponseFactory(),
+    Psr17FactoryDiscovery::findStreamFactory(),
+);
+
+$route = $builder->withMethod('GET')
+    ->withPath('/country')
+    ->withStringResponse(static function (RequestInterface $request): bool {
+        parse_str($request->getUri()->getQuery(), $requestParameters);
+
+        return ($requestParameters['code'] ?? '') === 'AU';
+    }, '{"id":"+43","code":"AU","name":"Austria"}')
+    ->withStringResponse(static function (RequestInterface $request): bool {
+        parse_str($request->getUri()->getQuery(), $requestParameters);
+
+        return ($requestParameters['code'] ?? '') === 'IT';
+    }, '{"id":"+39","code":"IT","name":"Italy"}')
+    ->build();
+
+// Request #1
+$response = $route->getHandler()(new Request('GET', '/country?code=AU'));
+assert($response instanceof ResponseInterface);
+
+$this->assertEquals(200, $response->getStatusCode());
+
+$data = json_decode($response->getBody()->getContents(), true);
+$this->assertEquals('Austria', $data['name']);
+
+// Request #2
+$response = $route->getHandler()(new Request('GET', '/country?code=IT'));
+assert($response instanceof ResponseInterface);
+
+$this->assertEquals(200, $response->getStatusCode());
+
+$data = json_decode($response->getBody()->getContents(), true);
+$this->assertEquals('Italy', $data['name']);
+
+// Request #3 - Response not found
+$this->expectException(ResponseNotFound::class);
+$route->getHandler()(new Request('GET', '/country'));
+```

--- a/docs/route-with-callbacks.md
+++ b/docs/route-with-callbacks.md
@@ -1,44 +1,55 @@
 ## Route with callbacks
 
 ```php
-$builder = new CallbackRouteBuilder(
-    Psr17FactoryDiscovery::findResponseFactory(),
-    Psr17FactoryDiscovery::findStreamFactory(),
-);
+public function testRoute(): void
+{
+    $builder = new CallbackRouteBuilder(
+        Psr17FactoryDiscovery::findResponseFactory(),
+        Psr17FactoryDiscovery::findStreamFactory(),
+    );
 
-$route = $builder->withMethod('GET')
-    ->withPath('/country')
-    ->withStringResponse(static function (RequestInterface $request): bool {
+    $route = $builder->withMethod('GET')
+        ->withPath('/country')
+        ->withStringResponse(
+            $this->checkCountry('AU'),
+            '{"id":"+43","code":"AU","name":"Austria"}',
+        )
+        ->withStringResponse(
+            $this->checkCountry('IT'),
+            '{"id":"+39","code":"IT","name":"Italy"}',
+        )
+        ->build();
+
+    // Request #1
+    $response = $route->getHandler()(new Request('GET', '/country?code=AU'));
+    assert($response instanceof ResponseInterface);
+
+    $this->assertEquals(200, $response->getStatusCode());
+
+    $data = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals('Austria', $data['name']);
+
+    // Request #2
+    $response = $route->getHandler()(new Request('GET', '/country?code=IT'));
+    assert($response instanceof ResponseInterface);
+
+    $this->assertEquals(200, $response->getStatusCode());
+
+    $data = json_decode($response->getBody()->getContents(), true);
+    $this->assertEquals('Italy', $data['name']);
+
+    // Request #3 - Response not found
+    $this->expectException(ResponseNotFound::class);
+    $route->getHandler()(new Request('GET', '/country'));
+}
+
+/** @return callable(RequestInterface $request):bool */
+private function checkCountry(string $countryCode): callable
+{
+    return static function (RequestInterface $request) use ($countryCode): bool {
         parse_str($request->getUri()->getQuery(), $requestParameters);
 
-        return ($requestParameters['code'] ?? '') === 'AU';
-    }, '{"id":"+43","code":"AU","name":"Austria"}')
-    ->withStringResponse(static function (RequestInterface $request): bool {
-        parse_str($request->getUri()->getQuery(), $requestParameters);
-
-        return ($requestParameters['code'] ?? '') === 'IT';
-    }, '{"id":"+39","code":"IT","name":"Italy"}')
-    ->build();
-
-// Request #1
-$response = $route->getHandler()(new Request('GET', '/country?code=AU'));
-assert($response instanceof ResponseInterface);
-
-$this->assertEquals(200, $response->getStatusCode());
-
-$data = json_decode($response->getBody()->getContents(), true);
-$this->assertEquals('Austria', $data['name']);
-
-// Request #2
-$response = $route->getHandler()(new Request('GET', '/country?code=IT'));
-assert($response instanceof ResponseInterface);
-
-$this->assertEquals(200, $response->getStatusCode());
-
-$data = json_decode($response->getBody()->getContents(), true);
-$this->assertEquals('Italy', $data['name']);
-
-// Request #3 - Response not found
-$this->expectException(ResponseNotFound::class);
-$route->getHandler()(new Request('GET', '/country'));
+        return ($requestParameters['code'] ?? '') === $countryCode;
+    };
+}
 ```

--- a/src/MockedClient/Route/CallbackResponse.php
+++ b/src/MockedClient/Route/CallbackResponse.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoppioGancio\MockedClient\Route;
+
+use Psr\Http\Message\ResponseInterface;
+
+class CallbackResponse
+{
+    /** @var callable */
+    private $callback;
+
+    public function __construct(callable $callback, private ResponseInterface $response)
+    {
+        $this->callback = $callback;
+    }
+
+    public function getCallback(): callable
+    {
+        return $this->callback;
+    }
+
+    public function getResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/MockedClient/Route/CallbackRouteBuilder.php
+++ b/src/MockedClient/Route/CallbackRouteBuilder.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoppioGancio\MockedClient\Route;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class CallbackRouteBuilder extends Builder
+{
+    /** @var array<array{'callback': callable(RequestInterface $request):bool, 'response': ResponseInterface}>  */
+    private array $responses = [];
+
+    public function new(): self
+    {
+        return new self($this->responseFactory, $this->streamFactory);
+    }
+
+    /**
+     * @param callable(RequestInterface      $request):bool $callback
+     * @param array<string, string|string[]> $headers
+     *
+     * @return $this
+     */
+    public function withStringResponse(
+        callable $callback,
+        string $content,
+        int $httpStatus = 200,
+        array $headers = [],
+    ): self {
+        $response = $this->buildResponseFromString($content, $httpStatus, $headers);
+
+        return $this->withResponse($callback, $response);
+    }
+
+    /**
+     * @param callable(RequestInterface      $request):bool $callback
+     * @param array<string, string|string[]> $headers
+     *
+     * @return $this
+     */
+    public function withFileResponse(callable $callback, string $file, int $httpStatus = 200, array $headers = []): self
+    {
+        $response = $this->buildResponseFromFile($file, $httpStatus, $headers);
+
+        return $this->withResponse($callback, $response);
+    }
+
+    /**
+     * @param callable(RequestInterface $request):bool $callback
+     *
+     * @return $this
+     */
+    public function withResponse(callable $callback, ResponseInterface $response): self
+    {
+        $this->responses[] = [
+            'callback' => $callback,
+            'response' => $response,
+        ];
+
+        return $this;
+    }
+
+    /** @throws Exception\IncompleteRoute */
+    public function build(): Route
+    {
+        return $this->buildRoute(
+            $this->method,
+            $this->path,
+            (new CallbackRouteHandler($this->responses))(...),
+        );
+    }
+}

--- a/src/MockedClient/Route/CallbackRouteBuilder.php
+++ b/src/MockedClient/Route/CallbackRouteBuilder.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class CallbackRouteBuilder extends Builder
 {
-    /** @var array<array{'callback': callable(RequestInterface $request):bool, 'response': ResponseInterface}>  */
+    /** @var CallbackResponse[]  */
     private array $responses = [];
 
     public function new(): self
@@ -54,10 +54,7 @@ class CallbackRouteBuilder extends Builder
      */
     public function withResponse(callable $callback, ResponseInterface $response): self
     {
-        $this->responses[] = [
-            'callback' => $callback,
-            'response' => $response,
-        ];
+        $this->responses[] = new CallbackResponse($callback, $response);
 
         return $this;
     }

--- a/src/MockedClient/Route/CallbackRouteHandler.php
+++ b/src/MockedClient/Route/CallbackRouteHandler.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class CallbackRouteHandler
 {
-    /** @param array<array{'callback': callable(RequestInterface $request):bool, 'response': ResponseInterface}> $responses */
+    /** @param CallbackResponse[] $responses */
     public function __construct(private readonly array $responses)
     {
     }
@@ -18,8 +18,8 @@ class CallbackRouteHandler
     public function __invoke(RequestInterface $request): ResponseInterface
     {
         foreach ($this->responses as $couple) {
-            if ($couple['callback']($request)) {
-                return $couple['response'];
+            if ($couple->getCallback()($request)) {
+                return $couple->getResponse();
             }
         }
 

--- a/src/MockedClient/Route/CallbackRouteHandler.php
+++ b/src/MockedClient/Route/CallbackRouteHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoppioGancio\MockedClient\Route;
+
+use DoppioGancio\MockedClient\Route\Exception\ResponseNotFound;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class CallbackRouteHandler
+{
+    /** @param array<array{'callback': callable(RequestInterface $request):bool, 'response': ResponseInterface}> $responses */
+    public function __construct(private readonly array $responses)
+    {
+    }
+
+    public function __invoke(RequestInterface $request): ResponseInterface
+    {
+        foreach ($this->responses as $couple) {
+            if ($couple['callback']($request)) {
+                return $couple['response'];
+            }
+        }
+
+        throw new ResponseNotFound();
+    }
+}

--- a/src/MockedClient/Route/Exception/ResponseNotFound.php
+++ b/src/MockedClient/Route/Exception/ResponseNotFound.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoppioGancio\MockedClient\Route\Exception;
+
+use Exception;
+
+class ResponseNotFound extends Exception
+{
+}

--- a/tests/Route/CallbackRouteBuilderTest.php
+++ b/tests/Route/CallbackRouteBuilderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoppioGancio\MockedClient\Tests\Route;
+
+use DoppioGancio\MockedClient\Route\CallbackRouteBuilder;
+use GuzzleHttp\Psr7\Request;
+use Http\Discovery\Psr17FactoryDiscovery;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+use function assert;
+use function json_decode;
+use function parse_str;
+
+class CallbackRouteBuilderTest extends TestCase
+{
+    public function testRoute(): void
+    {
+        $builder = new CallbackRouteBuilder(
+            Psr17FactoryDiscovery::findResponseFactory(),
+            Psr17FactoryDiscovery::findStreamFactory(),
+        );
+
+        $route = $builder->withMethod('GET')
+            ->withPath('/country')
+            ->withStringResponse(static function (RequestInterface $request): bool {
+                parse_str($request->getUri()->getQuery(), $requestParameters);
+
+                return $requestParameters['code'] === 'AU';
+            }, '{"id":"+43","code":"AU","name":"Austria"}')
+            ->withStringResponse(static function (RequestInterface $request): bool {
+                parse_str($request->getUri()->getQuery(), $requestParameters);
+
+                return $requestParameters['code'] === 'IT';
+            }, '{"id":"+39","code":"IT","name":"Italy"}')
+            //->withStringResponse('{"id":"+39","code":"IT","name":"Italy"}')
+            ->build();
+
+        // Request #1
+        $response = $route->getHandler()(new Request('GET', '/country?code=AU'));
+        assert($response instanceof ResponseInterface);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+        $this->assertEquals('Austria', $data['name']);
+
+        // Request #2
+        $response = $route->getHandler()(new Request('GET', '/country?code=IT'));
+        assert($response instanceof ResponseInterface);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+        $this->assertEquals('Italy', $data['name']);
+//        // Request #3 - Called too many times
+//        $this->expectException(TooManyConsecutiveCalls::class);
+//        $route->getHandler()(new Request('GET', '/country'));
+    }
+}

--- a/tests/Route/CallbackRouteBuilderTest.php
+++ b/tests/Route/CallbackRouteBuilderTest.php
@@ -27,16 +27,14 @@ class CallbackRouteBuilderTest extends TestCase
 
         $route = $builder->withMethod('GET')
             ->withPath('/country')
-            ->withStringResponse(static function (RequestInterface $request): bool {
-                parse_str($request->getUri()->getQuery(), $requestParameters);
-
-                return ($requestParameters['code'] ?? '') === 'AU';
-            }, '{"id":"+43","code":"AU","name":"Austria"}')
-            ->withStringResponse(static function (RequestInterface $request): bool {
-                parse_str($request->getUri()->getQuery(), $requestParameters);
-
-                return ($requestParameters['code'] ?? '') === 'IT';
-            }, '{"id":"+39","code":"IT","name":"Italy"}')
+            ->withStringResponse(
+                $this->checkCountry('AU'),
+                '{"id":"+43","code":"AU","name":"Austria"}',
+            )
+            ->withStringResponse(
+                $this->checkCountry('IT'),
+                '{"id":"+39","code":"IT","name":"Italy"}',
+            )
             ->build();
 
         // Request #1
@@ -60,5 +58,15 @@ class CallbackRouteBuilderTest extends TestCase
         // Request #3 - Response not found
         $this->expectException(ResponseNotFound::class);
         $route->getHandler()(new Request('GET', '/country'));
+    }
+
+    /** @return callable(RequestInterface $request):bool */
+    private function checkCountry(string $countryCode): callable
+    {
+        return static function (RequestInterface $request) use ($countryCode): bool {
+            parse_str($request->getUri()->getQuery(), $requestParameters);
+
+            return ($requestParameters['code'] ?? '') === $countryCode;
+        };
     }
 }


### PR DESCRIPTION
```php
    public function testRoute(): void
    {
        $builder = new CallbackRouteBuilder(
            Psr17FactoryDiscovery::findResponseFactory(),
            Psr17FactoryDiscovery::findStreamFactory(),
        );

        $route = $builder->withMethod('GET')
            ->withPath('/country')
            ->withStringResponse(
                $this->checkCountry('AU'),
                '{"id":"+43","code":"AU","name":"Austria"}',
            )
            ->withStringResponse(
                $this->checkCountry('IT'),
                '{"id":"+39","code":"IT","name":"Italy"}',
            )
            ->build();

        // Request #1
        $response = $route->getHandler()(new Request('GET', '/country?code=AU'));
        assert($response instanceof ResponseInterface);

        $this->assertEquals(200, $response->getStatusCode());

        $data = json_decode($response->getBody()->getContents(), true);
        $this->assertEquals('Austria', $data['name']);

        // Request #2
        $response = $route->getHandler()(new Request('GET', '/country?code=IT'));
        assert($response instanceof ResponseInterface);

        $this->assertEquals(200, $response->getStatusCode());

        $data = json_decode($response->getBody()->getContents(), true);
        $this->assertEquals('Italy', $data['name']);

        // Request #3 - Response not found
        $this->expectException(ResponseNotFound::class);
        $route->getHandler()(new Request('GET', '/country'));
    }

    /** @return callable(RequestInterface $request):bool */
    private function checkCountry(string $countryCode): callable
    {
        return static function (RequestInterface $request) use ($countryCode): bool {
            parse_str($request->getUri()->getQuery(), $requestParameters);

            return ($requestParameters['code'] ?? '') === $countryCode;
        };
    }
```