### PR TITLE
Add Symfony inject helper guidance to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENT Instructions
+
+These notes explain how to work with this repository and how to guide agents on using the package.
+
+## How to use the package
+- The package provides a mocked HTTP client built around Guzzle. Point people to `README.md` for install and basic examples, and to the docs in `docs/` for advanced routes (file responses, callbacks, consecutive calls, middlewares).
+- Typical bootstrap in code samples:
+  - Build a `HandlerBuilder` with PSR-17 factories and an optional logger.
+  - Add routes with `RouteBuilder` using `withMethod`, `withPath`, and a `Response` or callback.
+  - Build the client via `ClientBuilder` and use `$client->request(...)` in tests.
+- Emphasize the "fail fast" approach: start with no routes and let failing tests suggest missing routes.
+- When explaining Symfony usage, prefer the "inject<clientName>" helper pattern: create a private method that builds the mocked client (optionally loading JSON fixtures for complex responses) and registers it in the container via `self::getContainer()` with the same service id used in production. This keeps autowired services working unchanged and encourages tests that exercise real deserialization paths.
+
+## Development workflow
+- Run the unit test suite with `composer test` when practical; use `composer phpstan` and `composer cs` for static analysis and coding standards.
+- Follow existing code style; avoid adding try/catch blocks around imports.
+
+## Commits and PRs
+- Use concise commit messages in the imperative mood (e.g., "Add AGENTS instructions").
+- Summaries in PR descriptions should highlight user-visible changes and any testing performed.

--- a/README.md
+++ b/README.md
@@ -96,11 +96,51 @@ DoppioGancio\MockedClient\Exception\RouteNotFound: Mocked route GET /admin/dashb
 ```
 
 ### Inject the client in the service container
-If you have a service container, add the client to it, so that every service depending on it will be able to auto wire.
-```php
-self::$container->set(Client::class, $client);
+If you have a service container, add the client to it, so that every service depending on it will be able to auto wire. In Symfony
+tests it is handy to wrap the setup in a private helper to keep fixtures close to your test logic and let services pull the client
+from the container by name.
 
-// In Symfony
-self::$container->set('eight_points_guzzle.client.my_client', $client);
+```php
+use DoppioGancio\MockedClient\HandlerBuilder;
+use DoppioGancio\MockedClient\ClientBuilder;
+use DoppioGancio\MockedClient\Route\RouteBuilder;
+use GuzzleHttp\Psr7\Response;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Psr\Log\NullLogger;
+
+private function injectGoogleApiClient(string $fixturePath): void
+{
+    $handlerBuilder = new HandlerBuilder(
+        Psr17FactoryDiscovery::findServerRequestFactory(),
+        new NullLogger(),
+    );
+
+    $route = new RouteBuilder(
+        Psr17FactoryDiscovery::findResponseFactory(),
+        Psr17FactoryDiscovery::findStreamFactory(),
+    );
+
+    $handlerBuilder->addRoute(
+        $route->new()
+            ->withMethod('GET')
+            ->withPath('/external/resource')
+            ->withResponse(new Response(200, [], file_get_contents($fixturePath)))
+            ->build()
+    );
+
+    $clientBuilder = new ClientBuilder($handlerBuilder);
+    $mockedClient = $clientBuilder->build();
+
+    self::getContainer()->set('eight_points_guzzle.client.google_api', $mockedClient);
+}
 ```
+
+Benefits:
+
+- Every service depending on `eight_points_guzzle.client.google_api` keeps working via autowiring.
+- Complex responses can be loaded from JSON fixtures (even copied from real API calls), which also exercises your
+  deserialization logic instead of hand-crafting PHP unit mocks.
+
+For non-Symfony projects, you can apply the same approach by registering `$mockedClient` in your DI container using the class
+name or service identifier your application expects.
 


### PR DESCRIPTION
## Summary
- document the preferred inject<clientName> helper pattern for Symfony usage in AGENTS.md
- note using JSON fixtures when building mocked clients to keep autowired services unchanged

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b74e49500832c8762435a423f3e87)